### PR TITLE
When JUPYTERHUB_URL is just a path try to prepend request.origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ python setup.py develop
 
 ```bash
 # JUPYTERHUB_TOKEN env var should be set to same value as token in jupyterhub_config.py
+# JUPYTERHUB_URL is URL where JupyterHub is running. If path like `/jupyter` then origin header is appended.
 export JUPYTERHUB_URL=http://172.17.0.1:8000
 gunicorn -w 4 -b 0.0.0.0:8888 ewatercycle_experiment_launcher.serve:app
 ```

--- a/ewatercycle_experiment_launcher/process.py
+++ b/ewatercycle_experiment_launcher/process.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import connexion
 from flask import current_app
+from flask import request
 from nbformat import NotebookNode
 
 from ewatercycle_experiment_launcher.hub import JupyterHubClient
@@ -11,6 +12,8 @@ from ewatercycle_experiment_launcher.hub import JupyterHubClient
 def build_client() -> JupyterHubClient:
     token = current_app.config['JUPYTERHUB_TOKEN']
     jupyterhub_url = current_app.config['JUPYTERHUB_URL']
+    if jupyterhub_url.startswith('/') and request.origin:
+        jupyterhub_url = request.origin + jupyterhub_url
     username = connexion.context['user']
     return JupyterHubClient(jupyterhub_url, token, username)
 


### PR DESCRIPTION
Allows usage of `JUPYTERHUB_URL='/jupyter'`

Fixes #26